### PR TITLE
make search work as expected

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -58,7 +58,7 @@ export default class DistrictRepository {
 
     const searchResult = keysArray.filter(district => {
       search = search.toUpperCase();
-      return district.includes(search);
+      return district.startsWith(search);
       })
 
       searchResult.forEach( result => {


### PR DESCRIPTION
Updated contains to starts with. Search is working as it would in my head, but maybe I am thinking about it the wrong way. We can go back to contains. Either way no async issue. 